### PR TITLE
docker-compose for simple env setup

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  train:
+    image: tensorflow/tensorflow
+    volumes:
+    - "$PWD:/work"
+    ports:
+    - "6006:6006"
+    working_dir: /work
+    command: /bin/bash


### PR DESCRIPTION
Hi, I have prepared the docker-compose file which enables running whole Codelab in docker container which simplifies the initial setup.
it may be run like this:
`docker-compose run --service-ports train`