### PR TITLE
Fix a bug that event file could not be written

### DIFF
--- a/scripts/graph_pb2tb.py
+++ b/scripts/graph_pb2tb.py
@@ -33,6 +33,7 @@ def graph_to_tensorboard(graph, out_dir):
   with tf.Session():
     train_writer = tf.summary.FileWriter(out_dir)
     train_writer.add_graph(graph)
+    train_writer.close()
   
   
 def main(out_dir, graph_pb_path):


### PR DESCRIPTION
Without train_writer.close(), event file could not be written. It might be race condition of program ending and event file writing. Actually, if I run this script step by step by python debugger, event file can be correctly written to disk. But it fails, if I run the the script by "python -m" in terminal.