### PR TITLE
Remove error from CameraExampleViewController.mm

### DIFF
--- a/ios/tflite/CameraExampleViewController.mm
+++ b/ios/tflite/CameraExampleViewController.mm
@@ -26,7 +26,7 @@
 #include "tensorflow/contrib/lite/kernels/register.h"
 #include "tensorflow/contrib/lite/model.h"
 #include "tensorflow/contrib/lite/string_util.h"
-#include "tensorflow/contrib/lite/tools/mutable_op_resolver.h"
+#include "tensorflow/contrib/lite/mutable_op_resolver.h"
 
 #define LOG(x) std::cerr
 


### PR DESCRIPTION
When running the project the first time, the project gives an error.
The import I modified is pointing to the wrong path, I edited so that it builds correctly.